### PR TITLE
Allow hiding rich presence entirely when AFK

### DIFF
--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -30,5 +30,6 @@ namespace Dalamud.RichPresence.Configuration
         public bool ShowParty = true;
 
         public bool ShowAfk = true;
+        public bool HideEntirelyWhenAfk = false;
     }
 }

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -59,6 +59,7 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Separator();
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowParty", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowParty);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowAFK", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowAfk);
+                ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceHideAFKEntirely", LocalizationLanguage.Plugin), ref RichPresenceConfig.HideEntirelyWhenAfk);
 
                 ImGui.PopStyleVar();
 

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -103,6 +103,10 @@
     "message": "Show away from keyboard status",
     "description": "Dalamud.RichPresence.Configuration.ShowAFK"
   },
+  "DalamudRichPresenceHideAFKEntirely": {
+    "message": "Hide rich presence status entirely when AFK",
+    "description": "Dalamud.RichPresence.Configuration.HideEntirelyWhenAfk"
+  },
   "DalamudRichPresenceInLoginQueue": {
     "message": "In Login Queue (#{0})",
     "description": "Dalamud.RichPresence.Details.InLoginQueue"

--- a/Dalamud.RichPresence/RichPresencePlugin.cs
+++ b/Dalamud.RichPresence/RichPresencePlugin.cs
@@ -389,15 +389,23 @@ namespace Dalamud.RichPresence
                 }
 
                 var onlineStatusEn = localPlayer.OnlineStatus.GetWithLanguage(ClientLanguage.English);
-                if (RichPresenceConfig.ShowAfk && onlineStatusEn != null && onlineStatusEn.Name.RawString.Contains("Away from Keyboard"))
+                var isAfk = onlineStatusEn != null && onlineStatusEn.Name.RawString.Contains("Away from Keyboard");
+                if (RichPresenceConfig.ShowAfk && isAfk)
                 {
                     var text = localPlayer.OnlineStatus.GameData!.Name.RawString;
                     richPresence.State = text;
                     richPresence.Assets.SmallImageKey = "away";
                 }
 
-                // Request new presence to be set
-                DiscordPresenceManager.SetPresence(richPresence);
+                if (RichPresenceConfig.HideEntirelyWhenAfk && isAfk)
+                {
+                    DiscordPresenceManager.ClearPresence();
+                }
+                else
+                {
+                    // Request new presence to be set
+                    DiscordPresenceManager.SetPresence(richPresence);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
does what it says on the tin: if this setting is enabled (disabled by default to match existing behaviour), the rich presence is cleared when AFK.

![image](https://github.com/reiichi001/Dalamud.RichPresence/assets/9433472/c7ea34d7-0417-4a3c-be9a-c7e059066fd0)

do I need to do anything special with the translations, or is adding the string to the `_en` file enough?