### PR TITLE
Wine support + use Dalamud.NET.Sdk

### DIFF
--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -31,5 +31,6 @@ namespace Dalamud.RichPresence.Configuration
 
         public bool ShowAfk = true;
         public bool HideEntirelyWhenAfk = false;
+        public bool RPCBridgeEnabled = true;
     }
 }

--- a/Dalamud.RichPresence/Dalamud.RichPresence.csproj
+++ b/Dalamud.RichPresence/Dalamud.RichPresence.csproj
@@ -1,15 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Dalamud.NET.Sdk/10.0.0">
     <PropertyGroup>
         <AssemblyName>Dalamud.RichPresence</AssemblyName>
-        <TargetFramework>net8.0-windows</TargetFramework>
-        <PlatformTarget>x64</PlatformTarget>
-        <LangVersion>11</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
         <NoWarn>IDE0003</NoWarn>
         <AssemblyVersion>2.0.4.1</AssemblyVersion>
-		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+        <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
     <PropertyGroup Label="Documentation">
@@ -30,51 +27,29 @@
         <DebugType>pdbonly</DebugType>
         <Optimize>true</Optimize>
     </PropertyGroup>
-    
+
+  <Target Name="DownloadWineDiscordIpcBridge" AfterTargets="AfterBuild">
+      <DownloadFile
+          SourceUrl="https://github.com/0e4ef622/wine-discord-ipc-bridge/releases/latest/download/winediscordipcbridge.exe"
+          DestinationFolder="$(OutDir)binaries" 
+          DestinationFileName="WineRPCBridge.exe" 
+          Condition="!Exists('$(OutDir)binaries\WineRPCBridge.exe')"
+      />
+      <DownloadFile
+          SourceUrl="https://raw.githubusercontent.com/0e4ef622/wine-discord-ipc-bridge/master/LICENSE"
+          DestinationFolder="$(OutDir)binaries"
+          DestinationFileName="WineRPCBridgeLICENSE.txt"
+          Condition="!Exists('$(OutDir)binaries\WineRPCBridgeLICENSE.txt')"
+      />
+  </Target>
+
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="2.1.13" />
         <PackageReference GeneratePathProperty="true" Include="DiscordRichPresence" Version="1.2.1.24" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Reference Include="FFXIVClientStructs">
-            <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Newtonsoft.Json">
-            <HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Dalamud">
-            <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="ImGui.NET">
-            <HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="ImGuiScene">
-            <HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Lumina">
-            <HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Lumina.Excel">
-            <HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
     </ItemGroup>
 
     <ItemGroup>
         <Content Remove="Resources/loc/*.json" />
     </ItemGroup>
-
     <ItemGroup>
         <None Condition=" '$(Configuration)' == 'Debug' " Include="icon.png">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Dalamud.RichPresence/Dalamud.RichPresence.json
+++ b/Dalamud.RichPresence/Dalamud.RichPresence.json
@@ -6,6 +6,8 @@
   "InternalName": "Dalamud.RichPresence",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/goaaats/Dalamud.RichPresence",
-  "Changelog": "API 10 compatibility",
-  "Tags": [ "Discord" ]
+  "Changelog": "Add support for Rich Presence when the plugin is ran under WINE (@Blooym)",
+  "Tags": [
+    "Discord"
+  ]
 }

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -5,6 +5,7 @@ using ImGuiNET;
 using Dalamud.RichPresence.Configuration;
 using Dalamud.RichPresence.Models;
 using Dalamud.Interface.Utility;
+using Dalamud.Utility;
 
 namespace Dalamud.RichPresence.Interface
 {
@@ -24,8 +25,6 @@ namespace Dalamud.RichPresence.Interface
             {
                 return;
             }
-
-            
 
             ImGui.SetNextWindowSize(ImGuiHelpers.ScaledVector2(750, 520));
             var imGuiReady = ImGui.Begin(
@@ -61,6 +60,13 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowParty", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowParty);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowAFK", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowAfk);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceHideAFKEntirely", LocalizationLanguage.Plugin), ref RichPresenceConfig.HideEntirelyWhenAfk);
+
+                if (Util.IsWine())
+                {
+                    ImGui.Separator();
+                    ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgeEnabled", LocalizationLanguage.Plugin), ref RichPresenceConfig.RPCBridgeEnabled);
+                    ImGui.TextColored(ImGuiColors.DalamudGrey, RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceRPCBridgeEnabledDetail", LocalizationLanguage.Plugin));
+                }
 
                 ImGui.PopStyleVar();
 

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -122,5 +122,13 @@
   "DalamudRichPresenceShowLoginQueuePositionDetail": {
     "message": "This integration requires the Waitingway plugin to be installed.",
     "description": "Dalamud.RichPresence.Configuration.ShowLoginQueuePositionDetail"
+  },
+  "DalamudRichPresenceRPCBridgeEnabled": {
+    "message": "Enable WINE RPC Bridge",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgeEnabled"
+  },
+  "DalamudRichPresenceRPCBridgeEnabledDetail": {
+    "message": "Enable support for rich presence when running the game on Linux or MacOS (Applies on plugin restart).",
+    "description": "Dalamud.RichPresence.Configuration.RPCBridgeEnabledDetail"
   }
 }

--- a/Dalamud.RichPresence/packages.lock.json
+++ b/Dalamud.RichPresence/packages.lock.json
@@ -18,10 +18,68 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "DotNet.ReproducibleBuilds": {
+        "type": "Direct",
+        "requested": "[1.1.1, )",
+        "resolved": "1.1.1",
+        "contentHash": "+H2t/t34h6mhEoUvHi8yGXyuZ2GjSovcGYehJrS2MDm2XgmPfZL2Sdxg+uL2lKgZ4M6tTwKHIlxOob2bgh0NRQ==",
+        "dependencies": {
+          "Microsoft.SourceLink.AzureRepos.Git": "1.1.1",
+          "Microsoft.SourceLink.Bitbucket.Git": "1.1.1",
+          "Microsoft.SourceLink.GitHub": "1.1.1",
+          "Microsoft.SourceLink.GitLab": "1.1.1"
+        }
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.0.0",
         "contentHash": "VdLJOCXhZaEMY7Hm2GKiULmn7IEPFE4XC5LPSfBVCUIA8YLZVh846gtfBJalsPQF2PlzdD7ecX7DZEulJ402ZQ=="
+      },
+      "Microsoft.SourceLink.AzureRepos.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "qB5urvw9LO2bG3eVAkuL+2ughxz2rR7aYgm2iyrB8Rlk9cp2ndvGRCvehk3rNIhRuNtQaeKwctOl1KvWiklv5w==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Bitbucket.Git": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "cDzxXwlyWpLWaH0em4Idj0H3AmVo3L/6xRXKssYemx+7W52iNskj/SQ4FOmfCb8YQt39otTDNMveCZzYtMoucQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "WMcGpWKrmJmzrNeuaEb23bEMnbtR/vLmvZtkAP5qWu7vQsY59GqfRJd65sFpBszbd2k/bQ8cs8eWawQKAabkVg=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "IaJGnOv/M7UQjRJks7B6p7pbPnOwisYGOIzqCz5ilGFTApZ3ktOR+6zJ12ZRPInulBmdAf1SrGdDG2MU8g6XTw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
+      },
+      "Microsoft.SourceLink.GitLab": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "tvsg47DDLqqedlPeYVE2lmiTpND8F0hkrealQ5hYltSmvruy/Gr5nHAKSsjyw5L3NeM/HLMI5ORv7on/M4qyZw==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "1.1.1",
+          "Microsoft.SourceLink.Common": "1.1.1"
+        }
       },
       "Microsoft.Win32.Registry": {
         "type": "Transitive",


### PR DESCRIPTION
Port of my old PR at https://github.com/goaaats/Dalamud.RichPresence/pull/19. I didn't include the ability to change the RPC path because I don't really see it being all that useful and if anything it'd probably end up being a bit confusing. 

Minor caveat with running the bridge: It may not work when running XLCore inside of a flatpak (In the past I've seen it fail with a random Windows System32 exception), but since we want to move people away from the flatpak in the future I think it's better to implement because at worse it just wont work.

I also swapped this plugin to use Dalamud.NET.Sdk cause I needed to be able to build it on Linux.

If this functionality isn't desired I've also created a standalone plugin that does the exact same thing here https://github.com/Blooym/Dalamud.DiscordRpcWine and I can submit that to the main repository instead. Completely up to you.