### PR TITLE
add option to always show home world

### DIFF
--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -14,6 +14,8 @@ namespace Dalamud.RichPresence.Configuration
         public bool ShowFreeCompany = true;
         // Show world name
         public bool ShowWorld = true;
+        // Always show home world in details (even when on home world)
+        public bool AlwaysShowHomeWorld = false;
 
         // Show elapsed time in zones
         public bool ShowStartTime = false;

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -46,6 +46,7 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowName", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowName);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowFreeCompany", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowFreeCompany);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowWorld", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowWorld);
+                ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceAlwaysShowHomeWorld", LocalizationLanguage.Plugin), ref RichPresenceConfig.AlwaysShowHomeWorld);
                 ImGui.Separator();
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowStartTime", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowStartTime);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceResetTimeWhenChangingZones", LocalizationLanguage.Plugin), ref RichPresenceConfig.ResetTimeWhenChangingZones);

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -67,6 +67,10 @@
     "message": "Show world name",
     "description": "Dalamud.RichPresence.Configuration.ShowWorld"
   },
+  "DalamudRichPresenceAlwaysShowHomeWorld": {
+    "message": "Always show home world",
+    "description": "Dalamud.RichPresence.Configuration.AlwaysShowHomeWorld"
+  },
   "DalamudRichPresenceShowStartTime": {
     "message": "Show elapsed time in zones",
     "description": "Dalamud.RichPresence.Configuration.ShowStartTime"

--- a/Dalamud.RichPresence/RichPresencePlugin.cs
+++ b/Dalamud.RichPresence/RichPresencePlugin.cs
@@ -304,18 +304,21 @@ namespace Dalamud.RichPresence
                     
                     //TODO: Fix this
 
-                    // Show free company tag if configured
+                    // Show free company tag if configured and on home world
                     if (RichPresenceConfig.ShowFreeCompany && localPlayer.CurrentWorld.RowId == localPlayer.HomeWorld.RowId)
                     {
                         var fcTag = localPlayer.CompanyTag.TextValue;
-
-                        // Append free company tag to player name if it exists
                         richPresenceDetails = string.IsNullOrEmpty(fcTag) ? richPresenceDetails : $"{richPresenceDetails} «{fcTag}»";
                     }
-                    else if (RichPresenceConfig.ShowWorld && localPlayer.CurrentWorld.RowId != localPlayer.HomeWorld.RowId)
+
+                    // show home world in details - when visiting another world, or always if configured
+                    if (RichPresenceConfig.ShowWorld && localPlayer.CurrentWorld.RowId != localPlayer.HomeWorld.RowId)
                     {
-                        // Append home world name to current player name while visiting another world
-                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";                       
+                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";
+                    }
+                    else if (RichPresenceConfig.AlwaysShowHomeWorld)
+                    {
+                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";
                     }
                 }
                 else


### PR DESCRIPTION
home world name only shows in the details line when visiting another world right now. this adds an "always show home world" checkbox so it appends the ❀ HomeWorld to your name even when you're on your home world. works alongside the FC tag too - you'd get something like `Name «FC» ❀ Cactuar`.