### PR TITLE
hide presence during cutscenes

### DIFF
--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -14,6 +14,8 @@ namespace Dalamud.RichPresence.Configuration
         public bool ShowFreeCompany = true;
         // Show world name
         public bool ShowWorld = true;
+        // Always show home world in details (even when on home world)
+        public bool AlwaysShowHomeWorld = false;
 
         // Show elapsed time in zones
         public bool ShowStartTime = false;

--- a/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
+++ b/Dalamud.RichPresence/Configuration/RichPresenceConfig.cs
@@ -33,6 +33,7 @@ namespace Dalamud.RichPresence.Configuration
 
         public bool ShowAfk = true;
         public bool HideEntirelyWhenAfk = false;
+        public bool HideInCutscene = false;
         public bool RPCBridgeEnabled = true;
     }
 }

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -46,6 +46,7 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowName", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowName);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowFreeCompany", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowFreeCompany);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowWorld", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowWorld);
+                ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceAlwaysShowHomeWorld", LocalizationLanguage.Plugin), ref RichPresenceConfig.AlwaysShowHomeWorld);
                 ImGui.Separator();
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowStartTime", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowStartTime);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceResetTimeWhenChangingZones", LocalizationLanguage.Plugin), ref RichPresenceConfig.ResetTimeWhenChangingZones);

--- a/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
+++ b/Dalamud.RichPresence/Interface/RichPresenceConfigWindow.cs
@@ -61,6 +61,7 @@ namespace Dalamud.RichPresence.Interface
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowParty", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowParty);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceShowAFK", LocalizationLanguage.Plugin), ref RichPresenceConfig.ShowAfk);
                 ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceHideAFKEntirely", LocalizationLanguage.Plugin), ref RichPresenceConfig.HideEntirelyWhenAfk);
+                ImGui.Checkbox(RichPresencePlugin.LocalizationManager.Localize("DalamudRichPresenceHideInCutscene", LocalizationLanguage.Plugin), ref RichPresenceConfig.HideInCutscene);
 
                 if (Util.IsWine())
                 {

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -67,6 +67,10 @@
     "message": "Show world name",
     "description": "Dalamud.RichPresence.Configuration.ShowWorld"
   },
+  "DalamudRichPresenceAlwaysShowHomeWorld": {
+    "message": "Always show home world",
+    "description": "Dalamud.RichPresence.Configuration.AlwaysShowHomeWorld"
+  },
   "DalamudRichPresenceShowStartTime": {
     "message": "Show elapsed time in zones",
     "description": "Dalamud.RichPresence.Configuration.ShowStartTime"

--- a/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
+++ b/Dalamud.RichPresence/Resources/loc/dalamud_richpresence_en.json
@@ -111,6 +111,10 @@
     "message": "Hide rich presence status entirely when AFK",
     "description": "Dalamud.RichPresence.Configuration.HideEntirelyWhenAfk"
   },
+  "DalamudRichPresenceHideInCutscene": {
+    "message": "Hide rich presence during cutscenes",
+    "description": "Dalamud.RichPresence.Configuration.HideInCutscene"
+  },
   "DalamudRichPresenceInLoginQueue": {
     "message": "In Login Queue (#{0})",
     "description": "Dalamud.RichPresence.Details.InLoginQueue"

--- a/Dalamud.RichPresence/RichPresencePlugin.cs
+++ b/Dalamud.RichPresence/RichPresencePlugin.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using Dalamud.Game;
+using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.Command;
 using Dalamud.IoC;
 using Dalamud.Plugin;
@@ -44,6 +45,9 @@ namespace Dalamud.RichPresence
 
         [PluginService]
         internal static IPluginLog PluginLog { get; private set; } = null!;
+
+        [PluginService]
+        internal static ICondition Condition { get; private set; } = null!;
 
         internal static LocalizationManager? LocalizationManager { get; private set; }
         internal static DiscordPresenceManager? DiscordPresenceManager { get; private set; }
@@ -450,6 +454,16 @@ namespace Dalamud.RichPresence
                     var text = onlineStatusEn;
                     richPresence.State = text;
                     richPresence.Assets.SmallImageKey = "away";
+                }
+
+                // hide presence in cutscenes to avoid zone spoilers
+                var inCutscene = Condition[ConditionFlag.OccupiedInCutSceneEvent]
+                    || Condition[ConditionFlag.WatchingCutscene]
+                    || Condition[ConditionFlag.WatchingCutscene78];
+                if (RichPresenceConfig.HideInCutscene && inCutscene)
+                {
+                    DiscordPresenceManager.ClearPresence();
+                    return;
                 }
 
                 if (RichPresenceConfig.HideEntirelyWhenAfk && isAfk)

--- a/Dalamud.RichPresence/RichPresencePlugin.cs
+++ b/Dalamud.RichPresence/RichPresencePlugin.cs
@@ -304,18 +304,21 @@ namespace Dalamud.RichPresence
                     
                     //TODO: Fix this
 
-                    // Show free company tag if configured
+                    // Show free company tag if configured and on home world
                     if (RichPresenceConfig.ShowFreeCompany && localPlayer.CurrentWorld.RowId == localPlayer.HomeWorld.RowId)
                     {
                         var fcTag = localPlayer.CompanyTag.TextValue;
-
-                        // Append free company tag to player name if it exists
                         richPresenceDetails = string.IsNullOrEmpty(fcTag) ? richPresenceDetails : $"{richPresenceDetails} «{fcTag}»";
                     }
-                    else if (RichPresenceConfig.ShowWorld && localPlayer.CurrentWorld.RowId != localPlayer.HomeWorld.RowId)
+
+                    // show home world in details - when visiting another world, or always if configured
+                    if (RichPresenceConfig.ShowWorld && localPlayer.CurrentWorld.RowId != localPlayer.HomeWorld.RowId)
                     {
-                        // Append home world name to current player name while visiting another world
-                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";                       
+                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";
+                    }
+                    else if (RichPresenceConfig.AlwaysShowHomeWorld)
+                    {
+                        richPresenceDetails = $"{richPresenceDetails} ❀ {localPlayer.HomeWorld.Value.Name}";
                     }
                 }
                 else


### PR DESCRIPTION
adds option to clear discord presence while in cutscenes - avoids zone name spoilers showing up on your profile. checks OccupiedInCutSceneEvent, WatchingCutscene, and WatchingCutscene78 condition flags to cover all the ways the game marks cutscene state. off by default.